### PR TITLE
GitHub Copilot Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 *The Jupyter AI Agents are equipped with tools like 'execute', 'insert_cell', and more, to transform your Jupyter Notebooks into an intelligent, interactive workspace!*
 
-![Jupyter AI Agents](https://assets.datalayer.tech/jupyter-ai-agents/ai-agents-prompt-demo-terminal.gif)
+![Jupyter AI Agents](https://assets.datalayer.tech/jupyter-ai-agent/ai-agent-prompt-demo-terminal.gif)
 
 ```
 Jupyter AI Agents <-----------> JupyterLab
@@ -73,6 +73,8 @@ Start JupyterLab, setting a `port` and a `token` to be reused by the agent, and 
 jupyter lab --port 8888 --IdentityProvider.token MY_TOKEN
 ```
 
+Jupyter AI Agents supports multiple AI model providers (more information on [here](https://jupyter-ai-agents.datalayer.tech/docs/models/)). Here is an example with the Azure OpenAI provider.
+
 Read the [Azure Documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai) to get the needed credentials and make sure you define them in the following `.env` file.
 
 ```bash
@@ -90,23 +92,25 @@ To use the Jupyter AI Agents, an easy way is to launch a CLI (update the Azure d
 jupyter-ai-agents prompt \
   --url http://localhost:8888 \
   --token MY_TOKEN \
-  --azure-ai-deployment-name gpt-40-mini \
+  --model-provider azure-openai \
+  --model-name gpt-4o-mini \
   --path test.ipynb \
   --input "Create a matplotlib example"
 ```
 
-![Jupyter AI Agents](https://assets.datalayer.tech/jupyter-ai-agents/ai-agents-prompt-demo-terminal.gif)
+![Jupyter AI Agents](https://assets.datalayer.tech/jupyter-ai-agent/ai-agent-prompt-demo-terminal.gif)
 
 ```bash
 # Explain Error agent example.
 jupyter-ai-agents explain-error \
   --url http://localhost:8888 \
   --token MY_TOKEN \
-  --azure-ai-deployment-name gpt-40-mini \
+  --model-provider azure-openai \
+  --model-name gpt-4o-mini \
   --path test.ipynb
 ```
 
-![Jupyter AI Agents](https://assets.datalayer.tech/jupyter-ai-agents/ai-agents-explainerror-demo-terminal.gif)
+![Jupyter AI Agents](https://assets.datalayer.tech/jupyter-ai-agent/ai-agent-explainerror-demo-terminal.gif)
 
 ## Uninstall
 

--- a/docs/docs/agents/explain_error/index.mdx
+++ b/docs/docs/agents/explain_error/index.mdx
@@ -11,7 +11,8 @@ The Explain Error Agent explains an error encountered in a notebook. It leverage
 jupyter-ai-agents explain-error \
   --url http://localhost:8888 \
   --token MY_TOKEN \
-  --azure-ai-deployment-name gpt-40-mini \
+  --model-provider azure-openai \
+  --model-name gpt-4o-mini \
   --path test.ipynb
 ```
 
@@ -19,6 +20,7 @@ jupyter-ai-agents explain-error \
 
 - `--url`: JupyterLab URL.
 - `--token`: JupyterLab token.
-- `--azure-ai-deployment-name`: Azure AI model deployment name.
+- `--model-provider`: `azure-openai` or `github-copilot`.
+- `--model-name`: Azure AI model deployment name or Github Copilot model to use.
 - `--path`: Notebook to modify path.
 - `--current-cell-index`: Optional flag to provide the index of the cell where the error is encountered. If not provided, the error considered is the first one in the notebook.

--- a/docs/docs/agents/prompt/index.mdx
+++ b/docs/docs/agents/prompt/index.mdx
@@ -1,9 +1,10 @@
 # Prompt Agent
 
-The Prompt Agent generates code cells based on natural language input. It leverages AI models to generate code, add new cells, and modify the notebook content. This is a great Agent to support the following use cases:
+The Prompt Agent generates code cells based on natural language input. It leverages AI models to generate code, markdown, add new cells, and modify the notebook content. This is a great Agent to support the following use cases:
 
 - Code Generation: Generate cells code based on natural language input.
-- Notebook Modification: Add new cells based on existing one.
+- Markdown Generation: Generate markdown cells based on natural language input.
+- Notebook Modification: Insert new cells based on existing one to your notebook.
 
 ![Jupyter AI Agents](https://assets.datalayer.tech/jupyter-ai-agents/ai-agent-prompt-demo-terminal.gif)
 
@@ -13,7 +14,8 @@ To use the Jupyter AI Agents, an easy way is to launch a CLI (update the Azure d
 jupyter-ai-agents prompt \
   --url http://localhost:8888 \
   --token MY_TOKEN \
-  --azure-ai-deployment-name gpt-40-mini \
+  - model-provider azure-openai \
+  --model-name gpt-4o-mini \
   --path test.ipynb \
   --input "Create a matplotlib example"
 ```
@@ -23,7 +25,8 @@ jupyter-ai-agents prompt \
 The Prompt Agent can be configured with the following parameters:
 - `--url`: JupyterLab URL.
 - `--token`: JupyterLab token.
-- `--azure-ai-deployment-name`: Azure AI model deployment name.
+- `--model-provider`: `azure-openai` or `github-copilot`.
+- `--model-name`: Azure AI model deployment name or Github Copilot model to use.
 - `--path`: Notebook to modify path.
 - `--input`: Natural language input.
 - `--full-context`: Optional flag to provide the full notebook context i.e. notebook content to the AI model (default: False).

--- a/docs/docs/models/github_copilot/_category_.yaml
+++ b/docs/docs/models/github_copilot/_category_.yaml
@@ -1,0 +1,2 @@
+label: "GitHub Copilot"
+position: 2

--- a/docs/docs/models/github_copilot/index.mdx
+++ b/docs/docs/models/github_copilot/index.mdx
@@ -1,0 +1,17 @@
+# GitHub Copilot
+
+Jupyter AI Agents supports models from [GitHub Copilot](https://copilot.github.com/).
+
+Read the [Langchain GitHubCopilot README](https://github.com/datalayer/langchain-github-copilot) to get the `GITHUB` token and make sur you define it in the following environment variable.
+
+```bash
+export GITHUB_TOKEN="..."
+```
+
+GitHub Copilot supports different models that you can specify using the `--model-name` parameter. The available models as of 2024-02-07 are 
+- gpt-4o
+- o1
+- o3-mini
+
+Make sure you have a GitHubCopilot subscription and have enabled the model you want to use in your GitHubCopilot settings.
+

--- a/docs/docs/models/index.mdx
+++ b/docs/docs/models/index.mdx
@@ -2,4 +2,6 @@ import DocCardList from '@theme/DocCardList';
 
 # Models
 
+Jupyter AI Agents can be used with multiple AI models providers.
+
 <DocCardList />

--- a/jupyter_ai_agents/__version__.py
+++ b/jupyter_ai_agents/__version__.py
@@ -4,4 +4,4 @@
 
 """Jupyter AI Agents."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/jupyter_ai_agents/agents/explain_error.py
+++ b/jupyter_ai_agents/agents/explain_error.py
@@ -5,13 +5,11 @@
 import logging
 
 from langchain.agents import tool
-from langchain.agents import AgentExecutor
 
-from jupyter_ydoc import YNotebook
 from jupyter_nbmodel_client import NbModelClient
 from jupyter_kernel_client import KernelClient
 
-from jupyter_ai_agents.providers.azure_openai import create_azure_open_ai_agents
+from jupyter_ai_agents.agents.utils import create_ai_agent
 from jupyter_ai_agents.tools import insert_execute_code_cell_tool
 from jupyter_ai_agents.utils import retrieve_cells_content_until_first_error, retrieve_cells_content_error
 
@@ -25,7 +23,7 @@ Ensure updates to cell indexing when new cells are inserted. Maintain the logica
 """
 
 
-def explain_error(notebook: NbModelClient, kernel: KernelClient, azure_deployment_name: str, current_cell_index: int) -> list:
+def explain_error(notebook: NbModelClient, kernel: KernelClient, model_provider: str, model_name: str, current_cell_index: int) -> list:
     """Explain and correct an error in a notebook based on the prior cells."""
 
     @tool
@@ -61,7 +59,6 @@ def explain_error(notebook: NbModelClient, kernel: KernelClient, azure_deploymen
     logger.debug("Prompt with content", system_prompt_final)
     logger.debug("Input", input)
 
-    agent = create_azure_open_ai_agents(azure_deployment_name, system_prompt_final, tools)
-    agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
-    
-    return list(agent_executor.stream({"input": input}))
+    agent = create_ai_agent(model_provider, model_name, system_prompt_final, tools)
+        
+    return list(agent.stream({"input": input}))

--- a/jupyter_ai_agents/agents/prompt.py
+++ b/jupyter_ai_agents/agents/prompt.py
@@ -3,12 +3,11 @@
 # BSD 3-Clause License
 
 from langchain.agents import tool
-from langchain.agents import AgentExecutor
 
 from jupyter_nbmodel_client import NbModelClient
 from jupyter_kernel_client import KernelClient
 
-from jupyter_ai_agents.providers.azure_openai import create_azure_open_ai_agents
+from jupyter_ai_agents.agents.utils import create_ai_agent
 from jupyter_ai_agents.tools import insert_execute_code_cell_tool, insert_markdown_cell_tool
 from jupyter_ai_agents.utils import retrieve_cells_content
 
@@ -19,7 +18,7 @@ Assume that no packages are installed in the notebook, so install them using !pi
 Ensure updates to cell indexing when new cells are inserted. Maintain the logical flow of execution by adjusting cell index as needed.
 """
 
-def prompt(notebook: NbModelClient, kernel: KernelClient, input: str, azure_deployment_name: str, full_context: bool, current_cell_index: int) -> list:
+def prompt(notebook: NbModelClient, kernel: KernelClient, input: str, model_provider: str, model_name: str, full_context: bool, current_cell_index: int) -> list:
     """From a given instruction, code and markdown cells are added to a notebook."""
 
     @tool
@@ -54,7 +53,6 @@ def prompt(notebook: NbModelClient, kernel: KernelClient, input: str, azure_depl
     else:
         system_prompt_final = system_prompt_enriched
         
-    agent = create_azure_open_ai_agents(azure_deployment_name, system_prompt_final, tools)
-    agent_executor = AgentExecutor(name="NotebookPromptAgent", agent=agent, tools=tools, verbose=True)
+    agent = create_ai_agent(model_provider, model_name, system_prompt_final, tools)
 
-    return list(agent_executor.stream({"input": input}))
+    return list(agent.stream({"input": input}))

--- a/jupyter_ai_agents/agents/utils.py
+++ b/jupyter_ai_agents/agents/utils.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2023-2024 Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+from jupyter_ai_agents.providers.azure_openai import create_azure_openai_agent
+from jupyter_ai_agents.providers.github_copilot import create_github_copilot_agent
+
+def create_ai_agent(model_provider: str, model_name: str, system_prompt_final: str, tools: list):
+    """Create an AI agent based on the model provider."""
+    if model_provider == "azure-openai": 
+        agent = create_azure_openai_agent(model_name, system_prompt_final, tools)
+    elif model_provider == "github-copilot":
+        agent = create_github_copilot_agent(model_name, system_prompt_final, tools)
+    else:
+        raise ValueError(f"Model provider {model_provider} is not supported.")
+    return agent

--- a/jupyter_ai_agents/app.py
+++ b/jupyter_ai_agents/app.py
@@ -53,7 +53,7 @@ class PromptAgentApp(JupyterAIAgentAskApp):
         super(PromptAgentApp, self).initialize(*args, **kwargs)
 
     def ask(self):
-        reply = prompt(self.notebook, self.kernel, super().input, super().azure_ai_deployment_name, self.full_context, self.current_cell_index)
+        reply = prompt(self.notebook, self.kernel, super().input, super().model_provider, super().model_name, self.full_context, self.current_cell_index)
         logger.debug("Reply", reply)
 
     def start(self):
@@ -78,7 +78,7 @@ class ExplainErrorAgentApp(JupyterAIAgentAskApp):
         super(ExplainErrorAgentApp, self).initialize(*args, **kwargs)
 
     def ask(self):
-        reply = explain_error(self.notebook, self.kernel, super().azure_ai_deployment_name, self.current_cell_index)
+        reply = explain_error(self.notebook, self.kernel, super().model_provider, super().model_name, self.current_cell_index)
         logger.debug("Reply", reply)
 
     def start(self):

--- a/jupyter_ai_agents/base.py
+++ b/jupyter_ai_agents/base.py
@@ -40,10 +40,11 @@ jupyter_ai_agents_aliases.update(
         "path": "JupyterAIAgentBaseApp.path",
         "agent": "JupyterAIAgentBaseApp.agent_name",
         "input": "JupyterAIAgentBaseApp.input",
+        "model-provider": "JupyterAIAgentBaseApp.model_provider",
         "openai-api-version": "JupyterAIAgentBaseApp.openai_api_version",
         "azure-openai-version": "JupyterAIAgentBaseApp.azure_openai_version",
         "azure-openai-api-key": "JupyterAIAgentBaseApp.azure_openai_api_key",
-        "azure-ai-deployment-name": "JupyterAIAgentBaseApp.azure_ai_deployment_name",
+        "model-name": "JupyterAIAgentBaseApp.model_name",
         "current-cell-index": "JupyterAIAgentBaseApp.current_cell_index",
     }
 )
@@ -73,9 +74,8 @@ class JupyterAIAgentBaseApp(JupyterApp):
     path = Unicode(
         "",
         config=True,
-        help="Jupyter Notebok path."
+        help="Jupyter Notebook path."
     )
-
     agent_name = Unicode(
         "prompt",
         config=True,
@@ -86,7 +86,11 @@ class JupyterAIAgentBaseApp(JupyterApp):
         config=True,
         help="Input."
     )
-
+    model_provider = Unicode(
+        "github-copilot",
+        config=True,
+        help="Model provider can be 'azure-openai' or 'github-copilot'."
+    )
     openai_api_version = Unicode(
         os.environ.get("OPENAI_API_VERSION"),
         help="""OpenAI version.""",
@@ -102,9 +106,18 @@ class JupyterAIAgentBaseApp(JupyterApp):
         help="""Azure OpenAI key.""",
         config=True,
     )
-    azure_ai_deployment_name = Unicode(
-        "",
-        help="""Azure AI deployment name.""",
+    github_token = Unicode(
+        os.environ.get("GITHUB_TOKEN"),
+        help="""Github token.""",
+        config=True,
+    )
+    model_name = Unicode(
+        "gpt-4o",
+        help=(
+            "The 'Azure AI deployment' name for 'azure-openai' model provider."
+            "For 'github-copilot' model provider, gpt-4o, o1, or o3-mini (as of 2024-02-07) "
+            "- check your GithubCopilot settings to make sure the model you want to use is enabled."""
+            ),
         config=True,
     )
     current_cell_index = Integer(

--- a/jupyter_ai_agents/providers/github_copilot.py
+++ b/jupyter_ai_agents/providers/github_copilot.py
@@ -2,15 +2,15 @@
 #
 # BSD 3-Clause License
 
-from langchain_openai import AzureChatOpenAI
+from langchain_github_copilot import ChatGithubCopilot
 from langchain.agents import AgentExecutor, create_openai_tools_agent
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 
 
-def create_azure_openai_agent(model_name: str, system_prompt: str, tools: list) -> dict:
-    """Create an agent from a set of tools and an Azure deployment"""
+def create_github_copilot_agent(model_name: str, system_prompt: str, tools: list) -> dict:
+    """Create an agent from a set of tools and a Github Copilot model"""
     
-    llm = AzureChatOpenAI(azure_deployment=model_name)
+    llm = ChatGithubCopilot(model_name=model_name)
 
     prompt = ChatPromptTemplate.from_messages(
     [

--- a/jupyter_ai_agents/tools.py
+++ b/jupyter_ai_agents/tools.py
@@ -2,10 +2,6 @@
 #
 # BSD 3-Clause License
 
-from dotenv import load_dotenv, find_dotenv
-
-from langchain.agents import tool
-
 from jupyter_nbmodel_client import NbModelClient
 from jupyter_kernel_client import KernelClient
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
   "langchain",
   "langchain-openai",
+  "langchain-github-copilot",
   "jupyter_kernel_client",
   "jupyter_nbmodel_client",
   "python-dotenv",


### PR DESCRIPTION
The main changes are:
- Github Copilot as new `model provider`
- `--model-provider` field to specify the AI model provider (currently: Azure OpenAI or GitHubCopilot).
- `--model-name` field to specify the Azure AI model deployment name or Github Copilot model to use.